### PR TITLE
Fix topics not being found

### DIFF
--- a/aws_cfn_kafka_admin_provider/aws_cfn_kafka_admin_provider.py
+++ b/aws_cfn_kafka_admin_provider/aws_cfn_kafka_admin_provider.py
@@ -89,10 +89,10 @@ def merge_topics(final, override, extend_all=False):
     """
     if keyisset("Topics", override):
         override_topics = Topics.parse_obj(override["Topics"]).dict()
-        if not extend_all and not keypresent("Topics", override_topics):
+        if keypresent("Topics", override_topics) and not extend_all:
             del override_topics["Topics"]
             final["Topics"].update(override_topics)
-        elif extend_all and keyisset("Topics", override_topics):
+        elif keyisset("Topics", override_topics) and extend_all:
             if keyisset("Topics", final["Topics"]):
                 merged_lists = override_topics["Topics"] + final["Topics"]["Topics"]
             else:

--- a/aws_cfn_kafka_admin_provider/aws_cfn_kafka_admin_provider.py
+++ b/aws_cfn_kafka_admin_provider/aws_cfn_kafka_admin_provider.py
@@ -92,12 +92,12 @@ def merge_topics(final, override, extend_all=False):
         if not extend_all and not keypresent("Topics", override_topics):
             del override_topics["Topics"]
             final["Topics"].update(override_topics)
-        elif (
-            extend_all
-            and keyisset("Topics", override_topics)
-            and keyisset("Topics", final["Topics"])
-        ):
-            merged_lists = override_topics["Topics"] + final["Topics"]["Topics"]
+        elif extend_all and keyisset("Topics", override_topics):
+            if keyisset("Topics", final["Topics"]):
+                merged_lists = override_topics["Topics"] + final["Topics"]["Topics"]
+            else:
+                merged_lists = override_topics["Topics"]
+
             topics = list({v["Name"]: v for v in merged_lists}.values())
             final["Topics"].update(override_topics)
             final["Topics"]["Topics"] = topics


### PR DESCRIPTION
No topics were being found despite being defined in yaml file. Bring logic of merge_topics in line with merge_acls to handle case when ['Topics']['Topics'] not defined in final.
